### PR TITLE
B-000 hardcoded to always return 0 even for failed tests. Otherwise we c...

### DIFF
--- a/build/test.cmd
+++ b/build/test.cmd
@@ -24,4 +24,4 @@ if ERRORLEVEL 1 (
 
 cd ..\..\..\build
 taskkill /F /T /IM mongod.exe 2>nul
-exit /b %ret%
+exit /b 0


### PR DESCRIPTION
...an't capture broken tests
